### PR TITLE
Pull Element.prototype from window object for compatibility with shimmed DOM environments during testing

### DIFF
--- a/lib/matches.js
+++ b/lib/matches.js
@@ -1,4 +1,4 @@
-var proto = Element.prototype;
+var proto = window.Element.prototype;
 var nativeMatches = proto.matches ||
     proto.matchesSelector ||
     proto.webkitMatchesSelector ||


### PR DESCRIPTION
When testing code, I am using `jsdom` to shim in a DOM environment under `global.window`. I was receiving an error: `ReferenceError: Element is not defined` when trying to run tests that depend on the dom-utils library. This change addressed the error by using the shimmed window object.
